### PR TITLE
Add optional port restriction for /metrics endpoint

### DIFF
--- a/src/Prometheus.Client.AspNetCore/PrometheusOptions.cs
+++ b/src/Prometheus.Client.AspNetCore/PrometheusOptions.cs
@@ -15,6 +15,11 @@ namespace Prometheus.Client.AspNetCore
         public string MapPath { get; set; } = "/metrics";
 
         /// <summary>
+        ///     When specified only allow access to metrics on this port, otherwise return 404, default = null.
+        /// </summary>
+        public int? Port { get; set; }
+
+        /// <summary>
         ///     CollectorRegistry intance
         /// </summary>
         public ICollectorRegistry CollectorRegistryInstance { get; set; } = CollectorRegistry.Instance;


### PR DESCRIPTION
I would like to restrict metrics to be only accessible inside of Kubernetes cluster and not outside. One way to do this is to setup authentication and authorization for the metrics endpoint, but that adds unnecessary management overhead.

A simpler way to do this is to expose the metrics only on port that is reachable within the cluster and not outside. This PR adds such filter by checking the port in the incoming request and returning 404 if it does not match. 

An example usage in the default ASP.NET Core 2.2 app with https redirection:

```csharp
## file Startup.cs
# put this before the https redirection (and also before authentication)
# use the new Port property on the options to specify the port to filter to
app.UsePrometheusServer(o => o.Port = 5005);
app.UseHttpsRedirection();
app.UseMvc();
```

``` csharp
## file Program.cs
# specify default and our monitoring ports to listen on
WebHost.CreateDefaultBuilder(args)
                .UseUrls(
                    "http://*:5000",
                    "https://*:5001",
                    "http://*:5005")
                .UseStartup<Startup>();
    }
```

To test this with the standard app you can run those queries. (e.g. via VSCode rest client)
```http
# returns metrics
GET http://localhost:5005/metrics

###

# returns 404
GET https://localhost:5001/metrics

###

# returns 404
GET http://localhost:5000/metrics

### 

# returns values
GET https://localhost:5001/api/values

###

# returns 307 redirect to https 
# and then values
GET http://localhost:5000/api/values

###

# accessing the rest of the api via the monitoring port
# is not restricted so this alse returns 307 redirect to https 
# and then values
GET http://localhost:5005/api/values
```